### PR TITLE
Add CSE 110 lab issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/lab-task.md
+++ b/.github/ISSUE_TEMPLATE/lab-task.md
@@ -1,0 +1,50 @@
+---
+name: Lab task
+description: Track a concrete CSE 110 lab deliverable with acceptance criteria and a quick self-check.
+title: "[Lab] "
+labels:
+  - task
+---
+
+## Title pattern
+
+Use `[Lab] Short description` so issues sort together and are easy to scan.
+
+## Part of the lab
+
+<!-- e.g. Part 1 Agile/GitHub, Part 2 HTML meeting minutes, passphrase scavenger hunt -->
+
+-
+
+## Scope / files
+
+<!-- Which files or areas of the repo this touches (paths, sections, or features) -->
+
+-
+
+## Acceptance criteria
+
+<!-- What “done” means; use checkboxes -->
+
+- [ ]
+- [ ]
+
+## Self-check
+
+<!-- Quick verification before opening a PR -->
+
+- [ ] Changes are limited to this scope
+- [ ] Linked PR will reference this issue (e.g. `Closes #…` in the PR description)
+
+---
+
+## Lab scope reference (this repo)
+
+Use these as examples when breaking work down—adjust to match your official write-up:
+
+| Area | Examples |
+| ---- | -------- |
+| Part 1 process | Custom labels, issue templates, `standup.md`, branch + PR workflow |
+| Part 2 passphrases | `part2.txt` entries from the scavenger hunt |
+| Meeting minutes (HTML) | `index.html`: semantic regions (`header` / `main` / `footer`), `details` + `nav` TOC, sections (attendance, agenda, media, adjournment), feedback `form` (inputs, `fieldset`, `datalist`, `select`, `button`), images and `video` / `audio` with fallbacks |
+| Site / course | `README.md`, published GitHub Pages URL if required |


### PR DESCRIPTION
Closes #1

Adds `.github/ISSUE_TEMPLATE/` with a configurable chooser and a lab-task template (title pattern, scope, acceptance criteria, self-check, scope reference table).